### PR TITLE
Added StyleReset component with default browser styles for semantic html

### DIFF
--- a/src/components/spinner/spinner.tsx
+++ b/src/components/spinner/spinner.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled, { css, keyframes } from 'styled-components'
+import styled, { keyframes } from 'styled-components'
 
 type SpinnerProps = {
   size?: string

--- a/src/components/style-reset/index.ts
+++ b/src/components/style-reset/index.ts
@@ -1,0 +1,1 @@
+export { default } from './style-reset'

--- a/src/components/style-reset/style-reset.tsx
+++ b/src/components/style-reset/style-reset.tsx
@@ -1,0 +1,128 @@
+import {
+  space,
+  SpaceProps,
+  color,
+  ColorProps,
+  layout,
+  LayoutProps,
+  flexbox,
+  FlexboxProps,
+  position,
+  PositionProps,
+  border,
+  BorderProps,
+  shadow,
+  ShadowProps,
+} from 'styled-system'
+import styled, { css } from 'styled-components'
+
+interface As {
+  as?: React.ElementType
+}
+
+const defaultStyles = css`
+  & {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      font-weight: 700;
+      margin-top: 5px;
+      margin-bottom: 10px;
+    }
+
+    h1 {
+      font-family: Montserrat, sans-serif;
+      font-size: 40px;
+      line-height: 42px;
+      font-weight: 300;
+      color: #333;
+    }
+
+    h2 {
+      font-size: 22px;
+      line-height: 24px;
+    }
+
+    h3 {
+      margin: 0;
+      font-size: 20px;
+      line-height: 22px;
+    }
+
+    h4 {
+      font-size: 16px;
+      line-height: 18px;
+    }
+
+    ul,
+    ol {
+      margin: 1em 0;
+    }
+
+    p,
+    ul,
+    ol {
+      margin: 0 0 17px;
+    }
+
+    ul {
+      list-style: disc;
+    }
+
+    blockquote {
+      margin: 1em 40px;
+    }
+
+    b,
+    strong {
+      font-weight: bold;
+    }
+
+    table {
+      border-collapse: collapse;
+      border-spacing: 0;
+      width: 100%;
+    }
+
+    td,
+    th {
+      padding: 7px;
+      vertical-align: top;
+    }
+
+    td {
+      font-size: 14px;
+    }
+  }
+`
+
+export type BoxProps = React.RefAttributes<HTMLElement> &
+  React.HTMLAttributes<HTMLElement> &
+  LayoutProps &
+  ColorProps &
+  SpaceProps &
+  PositionProps &
+  FlexboxProps &
+  ShadowProps &
+  BorderProps &
+  As
+
+const StyleReset: React.FC<BoxProps> = styled.div`
+  ${border}
+  ${color}
+  ${flexbox}
+  ${layout}
+  ${position}
+  ${space}
+  ${shadow}
+  ${defaultStyles}
+`
+
+StyleReset.defaultProps = {
+  display: 'flex',
+}
+
+export default StyleReset

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import HtmlBlock from './components/html-block'
 import Skeleton from './components/skeleton'
 import Spinner from './components/spinner'
 import Stack from './components/stack'
+import StyleReset from './components/style-reset'
 
 import { ThemeProvider, theme, GlobalStyle } from './styles'
 
@@ -36,6 +37,7 @@ export {
   Skeleton,
   Spinner,
   Stack,
+  StyleReset,
   Text,
   theme,
   ThemeProvider,


### PR DESCRIPTION
This component would be used when dropping in markdown or plain html into a template where we want to use some basic semantic html styling rather than our normalized global css