### PR TITLE
Made Icon title required for a11y

### DIFF
--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -43,7 +43,7 @@ type IconProps = {
   name: string
   width?: number
   height?: number
-  title?: string
+  title: string
   titleId?: string
   descId?: string
   desc?: string

--- a/src/styles/custom-utils.ts
+++ b/src/styles/custom-utils.ts
@@ -207,6 +207,7 @@ export const buttonStyles = ({
         padding: 0;
         text-decoration: underline;
         border: none;
+        color: ${color}
       `
     }
 


### PR DESCRIPTION
Cypress a11y tests on the cms were failing on some pages because of missing title properties.

As we've updated some of the a11y rule sets, those pages were failing where they weren't previously.

Making the title prop mandatory lets us know when the pages using the Icon component are missing it.