### PR TITLE
Removed letter spacing from the button component

### DIFF
--- a/src/styles/custom-utils.ts
+++ b/src/styles/custom-utils.ts
@@ -52,7 +52,6 @@ const defaultButtonStyles = `
   font-weight: 400;
   transition: all 0.2s ease-in-out;
   min-width: 3rem;
-  letter-spacing: 1px;
   border-width: 1px !important;
   display: inline-block;
   border-width: 1px;


### PR DESCRIPTION
A previous business decision had us remove the uppercase styles on buttons.  The letter-spacing of 1px was done to support an all caps style.

The letter spacing now looks odd and out of place so this is meant to remove that.