### PR TITLE
Updated green button/link variant to have black text for a11y

### DIFF
--- a/src/components/style-reset/style-reset.tsx
+++ b/src/components/style-reset/style-reset.tsx
@@ -76,9 +76,35 @@ const defaultStyles = css`
       margin: 1em 40px;
     }
 
+    /* Font changes */
+
     b,
     strong {
       font-weight: bold;
+    }
+
+    i {
+    }
+
+    em {
+    }
+
+    mark {
+    }
+
+    small {
+    }
+
+    del {
+    }
+
+    ins {
+    }
+
+    sub {
+    }
+
+    sup {
     }
 
     table {

--- a/src/styles/custom-utils.ts
+++ b/src/styles/custom-utils.ts
@@ -11,7 +11,7 @@ const colors = {
   green: {
     bg: themeColors.green,
     hover: themeColors.greenDark,
-    text: themeColors.white,
+    text: themeColors.black,
   },
   blue: {
     bg: themeColors.blue,

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -371,7 +371,6 @@ const textVariants = {
     fontSize: '1.4rem',
     lineHeight: lineHeights.title,
     fontWeight: fontWeights.regular,
-    letterSpacing: letterSpacings.wide,
   },
   // milli = one size smaller than body
   milli: {


### PR DESCRIPTION
The new lighter green button variant with white text breaks a11y rules.  I've updated the variant to have black text.
<img width="247" alt="Screen Shot 2020-04-08 at 11 10 10 AM" src="https://user-images.githubusercontent.com/3803431/78800510-88279f80-7989-11ea-998a-95af0a6e985c.png">
