### PR TITLE
Brought back old green and rename new green to 'mintGreen'

### DIFF
--- a/src/styles/custom-utils.ts
+++ b/src/styles/custom-utils.ts
@@ -13,6 +13,11 @@ const colors = {
     hover: themeColors.greenDark,
     text: themeColors.black,
   },
+  mintGreen: {
+    bg: themeColors.mintGreen,
+    hover: themeColors.mintGreenDark,
+    text: themeColors.black,
+  },
   blue: {
     bg: themeColors.blue,
     hover: themeColors.blueDark,

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -48,12 +48,18 @@ const colors = {
   blackLight: '#222328',
   black: '#000000',
 
-  greenLightest: '#EEF7EE',
+  greenLightest: '#f3f5e6',
+  greenLighter: '#D3DCA3',
+  greenLight: '#A5C20F',
+  green: '#697e00',
+  greenDark: '#6B8000',
+
+  mintGreenLightest: '#EEF7EE',
   //greenLighter is our primary green
-  greenLighter: '#CDE7CB',
-  greenLight: '#ABD7A8',
-  green: '#8AC785',
-  greenDark: '#3D7A38',
+  mintGreenLighter: '#CDE7CB',
+  mintGreenLight: '#ABD7A8',
+  mintGreen: '#8AC785',
+  mintGreenDark: '#3D7A38',
 
   redLighter: '#F9BEAE',
   redLight: '#E37054',


### PR DESCRIPTION
The old green is still necessary when backfilling older components and pages that aren't ready for a color refactor.

This PR renames the new green to mintGreen and reintroduces the original green color into the theme