### PR TITLE
fixed typo in error message styling

### DIFF
--- a/src/components/input/input.styles.ts
+++ b/src/components/input/input.styles.ts
@@ -90,7 +90,7 @@ export const InputErrorMessage = styled.div`
       showErrorMessage &&
       `
 
-      max-height: 1000px
+      max-height: 1000px;
       opacity: 1;
     `
     )


### PR DESCRIPTION
Error Messages on the form Input component weren't showing.  Turned out to be a missing ";" at the end of one of the css props.

<img width="506" alt="Screen Shot 2020-04-20 at 4 09 21 PM" src="https://user-images.githubusercontent.com/3803431/79795067-5b786e00-8321-11ea-81d0-74e9a2579a99.png">
<img width="509" alt="Screen Shot 2020-04-20 at 4 09 33 PM" src="https://user-images.githubusercontent.com/3803431/79795075-5fa48b80-8321-11ea-9a7b-8b66d36b3c6a.png">

