### PR TITLE
Added 'hint' support for Input component

### DIFF
--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -11,6 +11,7 @@ const propTypes = {
   disabled: PropTypes.bool,
   errorMessage: PropTypes.string,
   hasError: PropTypes.bool,
+  hint: PropTypes.string,
   icon: PropTypes.node,
   id: PropTypes.string.isRequired,
   label: PropTypes.string,
@@ -49,6 +50,7 @@ const defaultProps = {
   type: 'text',
   value: '',
   isLoading: false,
+  hint: null,
 }
 
 const Input = React.forwardRef<HTMLInputElement>(
@@ -58,6 +60,7 @@ const Input = React.forwardRef<HTMLInputElement>(
       disabled,
       errorMessage,
       hasError,
+      hint,
       icon,
       id,
       label,
@@ -176,6 +179,16 @@ const Input = React.forwardRef<HTMLInputElement>(
         >
           <Text as="label" htmlFor={id}>
             {label}
+            {hint && (
+              <Text
+                mb={1}
+                variant="micro"
+                fontWeight="400"
+                textTransform="none"
+              >
+                {hint}
+              </Text>
+            )}
           </Text>
 
           {hasError && (


### PR DESCRIPTION
Support for Input "hints" has been added via the **hint** property.

This is where we can set input examples, formats, rules, etc...

It's included in the input's label in order to be read out by screen readers as the user focuses the input.

<img width="392" alt="Screen Shot 2020-04-22 at 3 36 42 PM" src="https://user-images.githubusercontent.com/3803431/80026328-f7d07b00-84af-11ea-90e9-e930d2c74580.png">
