### PR TITLE
Adjusted input label styling

### DIFF
--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -173,8 +173,8 @@ const Input = React.forwardRef<HTMLInputElement>(
           display="flex"
           flexDirection="column"
           fontWeight="semi"
-          fontSize="1rem"
-          textStyle="caps"
+          variant="milli"
+          textTransform="capitalize"
           htmlFor={id}
         >
           <Text as="label" htmlFor={id}>


### PR DESCRIPTION
Changed Input label styling to match the RW Input

Font size: 1.2rem (milli)
Text Transform: capitalize rather than uppercase