### PR TITLE
Changes required for MWP revisions

### DIFF
--- a/src/components/section.tsx
+++ b/src/components/section.tsx
@@ -10,6 +10,7 @@ const Section = ({ children, containerProps, ...rest }: SectionProps) => {
   return (
     <Box as="section" justifyContent="center" width={1} {...rest}>
       <Box
+        id="test"
         alignItems="center"
         flexDirection="column"
         width={1}

--- a/src/components/text.tsx
+++ b/src/components/text.tsx
@@ -11,6 +11,7 @@ import {
   textStyle,
   variant,
 } from 'styled-system'
+import { theme } from '../styles/theme'
 
 const textTransform = system({
   textTransform: true,
@@ -46,7 +47,7 @@ const Text = styled.div`
 `
 
 Text.defaultProps = {
-  lineHeight: '1.7',
+  lineHeight: theme.lineHeights.body
 }
 
 export default Text

--- a/src/components/text.tsx
+++ b/src/components/text.tsx
@@ -45,4 +45,8 @@ const Text = styled.div`
   ${textVariants}
 `
 
+Text.defaultProps = {
+  lineHeight: '1.7',
+}
+
 export default Text

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -135,7 +135,7 @@ const colors = {
     '#FF7EB4',
     '#FF94C1',
     '#FFA9CE',
-    '#FFBFDA',
+    '#FFBFDA',c
     '#FFE5F1',
   ],
 
@@ -286,33 +286,33 @@ const messageStyles = {
 const headingStyles = [
   {
     fontSize: '4.5rem',
-    lineHeight: lineHeights,
-    fontWeight: fontWeights.bold,
+    lineHeight: lineHeights.title,
+    fontWeight: fontWeights.light,
   },
   {
     fontSize: '3.2rem',
     lineHeight: lineHeights.title,
-    fontWeight: fontWeights.bold,
+    fontWeight: fontWeights.light,
   },
   {
     fontSize: '2.4rem',
     lineHeight: lineHeights.title,
-    fontWeight: fontWeights.bold,
+    fontWeight: fontWeights.light,
   },
   {
     fontSize: '1.8rem',
     lineHeight: lineHeights.title,
-    fontWeight: fontWeights.bold,
+    fontWeight: fontWeights.regular,
   },
   {
     fontSize: '1.6rem',
     lineHeight: lineHeights.title,
-    fontWeight: fontWeights.bold,
+    fontWeight: fontWeights.semi,
   },
   {
     fontSize: '1.4rem',
     lineHeight: lineHeights.title,
-    fontWeight: fontWeights.bold,
+    fontWeight: fontWeights.semi,
     letterSpacing: letterSpacings.wide,
   },
 ]

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -135,7 +135,7 @@ const colors = {
     '#FF7EB4',
     '#FF94C1',
     '#FFA9CE',
-    '#FFBFDA',c
+    '#FFBFDA',
     '#FFE5F1',
   ],
 
@@ -321,144 +321,118 @@ const textVariants = {
   // nina = three sizes larger than h1
   nina: {
     fontSize: '9.2rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.regular,
   },
   ninaBold: {
     fontSize: '9.2rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.regular,
   },
   // yotta = two sizes larger than h1
   yotta: {
     fontSize: '7.4rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.regular,
   },
   yottaBold: {
     fontSize: '7.4rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.bold,
   },
   // zetta = one size larger than h1
   zetta: {
     fontSize: '5.6rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.regular,
   },
   zettaBold: {
     fontSize: '5.6rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.bold,
   },
   // exa = h1
   exa: {
     fontSize: '4.8rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.regular,
   },
   exaBold: {
     fontSize: '4.8rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.bold,
   },
   // peta = h2
   peta: {
     fontSize: '3.2rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.regular,
   },
   petaBold: {
     fontSize: '3.2rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.bold,
   },
   // tera = three sizes larger than body
   tera: {
     fontSize: '2.4rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.regular,
   },
   teraBold: {
     fontSize: '2.4rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.bold,
   },
   // giga = two sizes larger than body
   giga: {
     fontSize: '1.8rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.regular,
   },
   gigaBold: {
     fontSize: '1.8rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.bold,
   },
   // mega = one size larger than body
   mega: {
     fontSize: '1.6rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.regular,
   },
   megaBold: {
     fontSize: '1.6rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.bold,
   },
   // kilo = body size but used for subheaders & is uppercase
   kilo: {
     fontSize: '1.4rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.regular,
   },
   kiloBold: {
     fontSize: '1.4rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.bold,
   },
   // pound = body
   pound: {
     fontSize: '1.4rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.regular,
   },
   poundBold: {
     fontSize: '1.4rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.bold,
   },
   // milli = one size smaller than body
   milli: {
     fontSize: '1.2rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.regular,
   },
   milliBold: {
     fontSize: '1.2rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.semi,
   },
   // micro = two sizes smaller than body
   micro: {
     fontSize: '1.0rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.regular,
   },
   microBold: {
     fontSize: '1.0rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.semi,
   },
   // nano = three sizes smaller than body
   nano: {
     fontSize: '0.8rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.regular,
   },
   nanoBold: {
     fontSize: '0.8rem',
-    lineHeight: lineHeights.title,
     fontWeight: fontWeights.semi,
   },
 }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -208,6 +208,7 @@ const lineHeights = {
   title: 1.2,
   body: 1.7,
   tall: 2,
+  long: 3,
 }
 
 const fontSizes = [12, 14, 16, 20, 24, 32, 48, 64, 96].map(remify)
@@ -285,33 +286,33 @@ const messageStyles = {
 const headingStyles = [
   {
     fontSize: '4.5rem',
-    lineHeight: lineHeights.title,
-    fontWeight: fontWeights.light,
+    lineHeight: lineHeights,
+    fontWeight: fontWeights.bold,
   },
   {
     fontSize: '3.2rem',
     lineHeight: lineHeights.title,
-    fontWeight: fontWeights.light,
+    fontWeight: fontWeights.bold,
   },
   {
     fontSize: '2.4rem',
     lineHeight: lineHeights.title,
-    fontWeight: fontWeights.light,
+    fontWeight: fontWeights.bold,
   },
   {
     fontSize: '1.8rem',
     lineHeight: lineHeights.title,
-    fontWeight: fontWeights.regular,
+    fontWeight: fontWeights.bold,
   },
   {
     fontSize: '1.6rem',
     lineHeight: lineHeights.title,
-    fontWeight: fontWeights.semi,
+    fontWeight: fontWeights.bold,
   },
   {
     fontSize: '1.4rem',
     lineHeight: lineHeights.title,
-    fontWeight: fontWeights.semi,
+    fontWeight: fontWeights.bold,
     letterSpacing: letterSpacings.wide,
   },
 ]


### PR DESCRIPTION
* What?
Removed "line-height" from text variants in theme.ts.

* Why?
Because we needed to increase the spaces between the lines to match the image on the right.
Removing the line-height from the text variant allows flexible use of any line height with any text size/style.
Also set a default line-height for <Text> to avoid breaking any other Text component without defined text variants.
Text variants will now include only font size and font-weight (e.g. bold).

![image](https://user-images.githubusercontent.com/22034059/87243070-c7d6ab00-c400-11ea-90f3-352ec7314090.png)
