### PR TITLE
Converted Link, Section, Grid and Stack to be forwardRef components

### DIFF
--- a/src/components/grid/grid.tsx
+++ b/src/components/grid/grid.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import Box from '../box'
 
-const Grid = ({ children, ...rest }) => {
+const Grid = React.forwardRef<HTMLDivElement>(({ children, ...rest }, ref) => {
   return (
-    <Box display="grid" {...rest}>
+    <Box ref={ref} display="grid" {...rest}>
       {children}
     </Box>
   )
-}
+})
 
 export default Grid

--- a/src/components/link.tsx
+++ b/src/components/link.tsx
@@ -35,44 +35,48 @@ const defaultProps = {
   variant: 'default',
 }
 
-const propTypes = {
-  ariaLabel: PropTypes.string.isRequired,
-  as: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  children: PropTypes.node.isRequired,
-  className: PropTypes.string,
-  display: PropTypes.string,
-  href: PropTypes.string,
-  to: PropTypes.string,
-  newTab: PropTypes.bool,
-  onClick: PropTypes.func,
-  testId: PropTypes.string,
-  variant: PropTypes.string,
+type LinkProps = {
+  ariaLabel: string
+  as?: string
+  children: React.ReactNode
+  className?: string
+  display?: string
+  href: string
+  id: string
+  to?: string
+  onClick?: Function
+  testId?: string
+  variant?: string
+  newTab?: boolean
 }
 
-const Link = ({ onClick, children, ariaLabel, newTab, testId, ...rest }) => {
-  if (!rest.href && !rest.to) {
-    console.warn('You must supply a `to` or `href` prop to Link!')
+const Link = React.forwardRef<HTMLLinkElement, LinkProps>(
+  ({ onClick, children, ariaLabel, newTab, testId, ...rest }, ref) => {
+    if (!rest.href && !rest.to) {
+      console.warn('You must supply a `to` or `href` prop to Link!')
+    }
+
+    const tabProps = newTab
+      ? { rel: 'noopener noreferrer', target: '_blank' }
+      : {}
+
+    return (
+      <StyledLink
+        ref={ref}
+        aria-label={ariaLabel}
+        data-testid={testId}
+        onClick={onClick}
+        title={ariaLabel}
+        {...rest}
+        {...tabProps}
+      >
+        {children}
+      </StyledLink>
+    )
   }
-
-  const tabProps = newTab
-    ? { rel: 'noopener noreferrer', target: '_blank' }
-    : {}
-
-  return (
-    <StyledLink
-      aria-label={ariaLabel}
-      data-testid={testId}
-      onClick={onClick}
-      title={ariaLabel}
-      {...rest}
-      {...tabProps}
-    >
-      {children}
-    </StyledLink>
-  )
-}
+)
 
 Link.defaultProps = defaultProps
-Link.propTypes = propTypes
+Link.displayName = 'Link'
 
 export default Link

--- a/src/components/section.tsx
+++ b/src/components/section.tsx
@@ -6,19 +6,21 @@ type SectionProps = {
   containerProps?: {}
 }
 
-const Section = ({ children, containerProps, ...rest }: SectionProps) => {
-  return (
-    <Box as="section" justifyContent="center" width={1} {...rest}>
-      <Box
-        alignItems="center"
-        flexDirection="column"
-        width={1}
-        {...containerProps}
-      >
-        {children}
+const Section = React.forwardRef<HTMLDivElement, SectionProps>(
+  ({ children, containerProps, ...rest }, ref) => {
+    return (
+      <Box ref={ref} as="section" justifyContent="center" width={1} {...rest}>
+        <Box
+          alignItems="center"
+          flexDirection="column"
+          width={1}
+          {...containerProps}
+        >
+          {children}
+        </Box>
       </Box>
-    </Box>
-  )
-}
+    )
+  }
+)
 
 export default Section

--- a/src/components/stack/stack.tsx
+++ b/src/components/stack/stack.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import Box from '../box'
 
-const Stack = ({ children, ...rest }) => {
+const Stack = React.forwardRef<HTMLDivElement>(({ children, ...rest }, ref) => {
   return (
-    <Box flexDirection="column" {...rest}>
+    <Box ref={ref} flexDirection="column" {...rest}>
       {children}
     </Box>
   )
-}
+})
 
 export default Stack


### PR DESCRIPTION
Using many of our generic components as building blocks for other, more complex components, we sometimes have the need to set a ref to the html.  This PR adds that capability to the Link, Section, Grid and Stack components.