### PR TITLE
Added new red color variant

### DIFF
--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -137,6 +137,7 @@ const colors = {
     '#FFA9CE',
     '#FFBFDA',
     '#FFE5F1',
+    '#B20101', /* New addition */
   ],
 
   pinks: [


### PR DESCRIPTION
Added new color due to the contrast issues in the failed cypress accessibility tests.
This new color is the color of the returned text for the new price component.

Example:

![image](https://user-images.githubusercontent.com/22034059/88341808-463e2180-cd0c-11ea-96c4-26388d5a7279.png)