### PR TITLE
B166678 - CMS link issue (fixed text/outline color mismatch)

### DIFF
--- a/src/styles/custom-utils.ts
+++ b/src/styles/custom-utils.ts
@@ -89,15 +89,15 @@ export const buttonStyles = ({
       text: theme.colors.black,
     },
     purple: {
-		bg: theme.colors.purple,
-		hover: theme.colors.purpleDark,
-		text: theme.colors.white,
-	  },
-	purpleDark: {
-		  bg: theme.colors.purpleDark,
-		  hover: theme.colors.purpleDark,
-		  text: theme.colors.white,
-	},
+      bg: theme.colors.purple,
+      hover: theme.colors.purpleDark,
+      text: theme.colors.white,
+    },
+    purpleDark: {
+      bg: theme.colors.purpleDark,
+      hover: theme.colors.purpleDark,
+      text: theme.colors.white,
+    },
   }
 
   const paddingVariants = {
@@ -158,7 +158,7 @@ export const buttonStyles = ({
       return `
         ${defaultButtonStyles}
         ${padding}
-        color: ${theme.black};
+        color: ${bg};
         background: ${theme.white};
         border-radius: ${radii.small};
         border-color: ${bg};


### PR DESCRIPTION
## Description  
  
* TP ID (TP 16678)  
* TP URL Link (https://rebel.tpondemand.com/entity/16678-cms-button-outline-font-colour-fix) 
* Inverse variant links (i.e. secondary buttons) failed to match text color with the button outline color
  
## Related PR's

* None

## Affected Areas  

* All pages with an inverse variant CTA button
* CMS Search: `"variant": "inverse"`

## Reviewer Checklist  

[ ] Build and tests completed successfully  
[ ] Follows Rebel code guidelines 

## Screenshot

Before...

![image](https://user-images.githubusercontent.com/22034059/119738120-315f7c80-be4e-11eb-80d1-33b50cf7eede.png)

![image](https://user-images.githubusercontent.com/22034059/119738331-8a2f1500-be4e-11eb-9306-e4b4b2ffe0eb.png)

After.... 

![image](https://user-images.githubusercontent.com/22034059/119739394-2c9bc800-be50-11eb-8bf2-d383d829e82b.png)

![image](https://user-images.githubusercontent.com/22034059/119738818-4ee11600-be4f-11eb-9920-1484ddee9c99.png)

