### PR TITLE
20437 - Moved from Google Fonts to TypeKit

### DIFF
--- a/src/styles/redesignTheme.js
+++ b/src/styles/redesignTheme.js
@@ -4,7 +4,7 @@ const theme = {
   ...baseTheme,
   fonts: {
     ...baseTheme.fonts,
-    title: `Shippori Mincho, serif;`,
+    title: `Merriweather, serif;`,
     body: `'Nunito Sans', sans-serif;`,
   },
   colors: {

--- a/src/styles/redesignTheme.js
+++ b/src/styles/redesignTheme.js
@@ -4,8 +4,8 @@ const theme = {
   ...baseTheme,
   fonts: {
     ...baseTheme.fonts,
-    title: `Merriweather, serif;`,
-    body: `'Nunito Sans', sans-serif;`,
+    title: `ivyjournal, sans-serif;`,
+    body: `'nunito-sans', sans-serif;`,
   },
   colors: {
     ...baseTheme.colors,

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -198,8 +198,8 @@ const colors = {
 // TYPOGRAPHY
 
 const fonts = {
-  title: `'Montserrat', sans-serif`,
-  body: `'Montserrat', sans-serif`,
+  title: `'montserrat', sans-serif`,
+  body: `'montserrat', sans-serif`,
   trustpilot: '"Segoe UI","Helvetica Neue","Helvetica","Arial","sans-serif"',
 }
 


### PR DESCRIPTION
## Description  
  
* TP 20437
* https://rebel.tpondemand.com/entity/20437-remove-typekit
* Ironically instead of moving off of TypeKit to Google Fonts, I went from Google Fonts to TypeKit
* Couldn't find alternative to Ivy Journal so using the Monsterrat and Nunito Sans in TypeKit
  
## Related PR's

List other open PR's that are part of this work, with links.
There will be PRs here that will be opened when this one gets approved to bump versions
  
* https://github.com/rebeldotcom/rebel-web-ui/pull/903
* https://github.com/rebeldotcom/rebel-web-cms/pull/1136
* https://github.com/rebeldotcom/rebel-web-components/pull/533

## Affected Areas  

* Headers on site

## Reviewer Checklist  

[ ] Build and tests completed successfully  
[ ] Follows Rebel code guidelines  
