### PR TITLE
HackWeek - LPS Ticket Form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8242,8 +8242,8 @@
             "binary-extensions": "^2.2.0",
             "diff": "^5.0.0",
             "minimatch": "^3.0.4",
-            "npm-package-arg": "^8.1.4",
-            "pacote": "^11.3.4",
+            "npm-package-arg": "^8.1.1",
+            "pacote": "^11.3.0",
             "tar": "^6.1.0"
           }
         },

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -172,6 +172,7 @@ const Input = React.forwardRef<HTMLInputElement>(
           ref={ref}
           disabled={disabled}
           id={id}
+          name={name}
           onChange={onChange}
           required={required}
           rows={rows}


### PR DESCRIPTION
Our Input component doesn't attach the name passed to it when the Input is flagged as a textarea; Input attaches name when it's a regular input.

Needed to work with formik