### PR TITLE
Added light orange color for the new navbar sale tag

### DIFF
--- a/src/styles/redesignTheme.js
+++ b/src/styles/redesignTheme.js
@@ -11,6 +11,7 @@ const redesignColors = {
   redLight: '#FFEEEE',
   red: '#E62E31',
   redDark: '#6B393F',
+  orangeLighter: '#ff9900',
   orangeLight: '#FFEBE6',
   orange: '#FF6600',
   orangeDark: '#C4470E',


### PR DESCRIPTION
New orange color ( #FF9900) for the sale tag on the new navigation bar.

![image](https://user-images.githubusercontent.com/22034059/133125879-2a51c5e9-167d-4284-b14c-74da80d6a374.png)