### PR TITLE
Added color to both themes

### DIFF
--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -41,6 +41,7 @@ const colors = {
   white: '#fff',
   whiteDark: '#f7f7f7',
   greyLightest: '#e7e7e7',
+  greyLighter: '#EFEFEF',
   greyLight: '#d7d7d7',
   grey: '#B2B2B2',
   greyDark: '#999999',


### PR DESCRIPTION
New color only available in redesign theme but not original theme.
We'll need to carefully fix this to make sure color codes are consistent and available for both original & redesign themes
It is a regular issue sometimes affecting Internic and Legacy pages (i.e. rebel-web-src).
Initial PR - https://github.com/rebeldotcom/rebel-web-components/pull/578