### PR TITLE
TP 23119 - FIX - Login history

### DIFF
--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -56,6 +56,7 @@ const Pagination = ({
   const [turns, setTurns] = useState(1)
   const offset = (current - 1) * countPerPage
 
+  /* Handles when the user clicks on a page number */
   const onPageSelect = (page, idx) => {
     setCurrent(page)
     if (idx === 0 && page !== 1) {
@@ -69,6 +70,7 @@ const Pagination = ({
     }
   }
 
+  /* Handles when user clicks the next button */
   const prevButton = () => {
     if (current > 1) {
       const prevPage = current - 1
@@ -78,6 +80,7 @@ const Pagination = ({
     }
   }
 
+  /* Handles when the user clicks the prev button */
   const nextButton = () => {
     if (current < Math.ceil(total / countPerPage)) {
       const nextPage = current + 1
@@ -99,6 +102,7 @@ const Pagination = ({
       width="100%"
       {...props}
     >
+      {/* Display a selector to choose number of rows to display */}
       {showRowSelector && (
         <Box mr={4}>
           <Text alignSelf="center" mr={2} variant="milli">
@@ -112,12 +116,16 @@ const Pagination = ({
           />
         </Box>
       )}
+      {/* Display the number of results, and the range of data being shown */}
       {showResultCount && (
         <Text mr={4}>
           {offset + 1}-{current * countPerPage} of {total}
         </Text>
       )}
+
+      {/* Primary Pagination logic  */}
       <Box key="pagination" alignItems="center" justifyContent="center">
+        {/* Don't show previous button on page 1 */}
         {current > 1 && (
           <PrevButton
             mr={3}
@@ -126,6 +134,7 @@ const Pagination = ({
             title="back"
           />
         )}
+
         {new Array(count).fill(1).map((_, idx) => {
           const pageNumber =
             currentIdx > Math.ceil((count - 1) / 2)
@@ -142,6 +151,7 @@ const Pagination = ({
             </PaginationButton>
           )
         })}
+
         <Icon name="arrow-right" onClick={nextButton} title="forward" />
       </Box>
     </Stack>

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -22,7 +22,7 @@ const PrevButton = styled(Icon)`
 `
 
 interface PaginationProps {
-  onPageChange: (offset: number) => {}
+  onPageChange: (offset: number, limit?: number) => {}
   rowsPerPage: number
   total: number
   count?: number
@@ -57,19 +57,17 @@ const Pagination = ({
   const offset = (current - 1) * countPerPage
   const didMount = useRef(true) // used to track if this is the first time the component renders
 
-  const maxCount =
-    Math.ceil(total / countPerPage) < count
-      ? Math.ceil(total / countPerPage)
-      : count
+  const lastPage = Math.ceil(total / countPerPage)
+  const lowerBound = Math.ceil((count - 1) / 2)
 
   /* Handles when the user clicks on a page number */
   const onPageSelect = (page, idx) => {
     setCurrent(page)
     if (idx === 0 && page !== 1) {
-      setCurrentIdx(Math.ceil((maxCount - 1) / 2))
+      setCurrentIdx(lowerBound)
       setTurns(turns - 1)
-    } else if (idx > Math.ceil((maxCount - 1) / 2)) {
-      setCurrentIdx(Math.ceil((maxCount - 1) / 2))
+    } else if (idx > lowerBound) {
+      setCurrentIdx(lowerBound)
       setTurns(turns + 1)
     } else {
       setCurrentIdx(idx)
@@ -80,8 +78,7 @@ const Pagination = ({
   const prevButton = () => {
     if (current > 1) {
       const prevPage = current - 1
-      const prevIndex =
-        currentIdx < 1 ? Math.ceil((maxCount - 1) / 2) : currentIdx - 1
+      const prevIndex = currentIdx < 1 ? lowerBound : currentIdx - 1
       onPageSelect(prevPage, prevIndex)
     }
   }
@@ -90,10 +87,7 @@ const Pagination = ({
   const nextButton = () => {
     if (current < Math.ceil(total / countPerPage)) {
       const nextPage = current + 1
-      const nextIndex =
-        currentIdx >= maxCount - 1
-          ? Math.ceil((maxCount - 1) / 2)
-          : currentIdx + 1
+      const nextIndex = currentIdx >= count - 1 ? lowerBound : currentIdx + 1
       onPageSelect(nextPage, nextIndex)
     }
   }
@@ -107,8 +101,8 @@ const Pagination = ({
       didMount.current = false
       return
     }
-    onPageChange(offset)
-  }, [current])
+    onPageChange(offset, countPerPage)
+  }, [current, countPerPage])
 
   return (
     <Stack
@@ -151,11 +145,10 @@ const Pagination = ({
           />
         )}
 
-        {new Array(maxCount).fill(1).map((_, idx) => {
+        {new Array(count).fill(1).map((_, idx) => {
           const pageNumber =
-            currentIdx > Math.ceil((maxCount - 1) / 2)
-              ? current + idx
-              : idx + turns
+            currentIdx > lowerBound ? current + idx : idx + turns
+          if (pageNumber > lastPage) return null
           return (
             <PaginationButton
               key={`page-${pageNumber}-${idx}`}
@@ -168,7 +161,7 @@ const Pagination = ({
           )
         })}
 
-        {maxCount > 1 && (
+        {count > 1 && current < lastPage && (
           <Icon name="arrow-right" onClick={nextButton} title="forward" />
         )}
       </Box>

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useRef, useLayoutEffect } from 'react'
 import styled from 'styled-components'
 import Box from './box'
 import Text from './text'
@@ -55,6 +55,7 @@ const Pagination = ({
   const [countPerPage, setCountPerPage] = useState(rowsPerPage)
   const [turns, setTurns] = useState(1)
   const offset = (current - 1) * countPerPage
+  const didMount = useRef(true) // used to track if this is the first time the component renders
 
   const maxCount =
     Math.ceil(total / countPerPage) < count
@@ -97,7 +98,15 @@ const Pagination = ({
     }
   }
 
-  useEffect(() => {
+  /**
+   * We only want to re-render if the value of `current` changes (on a page selection)
+   * We don't want the initial render
+   */
+  useLayoutEffect(() => {
+    if (didMount.current) {
+      didMount.current = false
+      return
+    }
     onPageChange(offset)
   }, [current])
 

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -56,14 +56,19 @@ const Pagination = ({
   const [turns, setTurns] = useState(1)
   const offset = (current - 1) * countPerPage
 
+  const maxCount =
+    Math.ceil(total / countPerPage) < count
+      ? Math.ceil(total / countPerPage)
+      : count
+
   /* Handles when the user clicks on a page number */
   const onPageSelect = (page, idx) => {
     setCurrent(page)
     if (idx === 0 && page !== 1) {
-      setCurrentIdx(Math.ceil((count - 1) / 2))
+      setCurrentIdx(Math.ceil((maxCount - 1) / 2))
       setTurns(turns - 1)
-    } else if (idx > Math.ceil((count - 1) / 2)) {
-      setCurrentIdx(Math.ceil((count - 1) / 2))
+    } else if (idx > Math.ceil((maxCount - 1) / 2)) {
+      setCurrentIdx(Math.ceil((maxCount - 1) / 2))
       setTurns(turns + 1)
     } else {
       setCurrentIdx(idx)
@@ -75,7 +80,7 @@ const Pagination = ({
     if (current > 1) {
       const prevPage = current - 1
       const prevIndex =
-        currentIdx < 1 ? Math.ceil((count - 1) / 2) : currentIdx - 1
+        currentIdx < 1 ? Math.ceil((maxCount - 1) / 2) : currentIdx - 1
       onPageSelect(prevPage, prevIndex)
     }
   }
@@ -85,7 +90,9 @@ const Pagination = ({
     if (current < Math.ceil(total / countPerPage)) {
       const nextPage = current + 1
       const nextIndex =
-        currentIdx >= count - 1 ? Math.ceil((count - 1) / 2) : currentIdx + 1
+        currentIdx >= maxCount - 1
+          ? Math.ceil((maxCount - 1) / 2)
+          : currentIdx + 1
       onPageSelect(nextPage, nextIndex)
     }
   }
@@ -135,9 +142,9 @@ const Pagination = ({
           />
         )}
 
-        {new Array(count).fill(1).map((_, idx) => {
+        {new Array(maxCount).fill(1).map((_, idx) => {
           const pageNumber =
-            currentIdx > Math.ceil((count - 1) / 2)
+            currentIdx > Math.ceil((maxCount - 1) / 2)
               ? current + idx
               : idx + turns
           return (
@@ -152,7 +159,9 @@ const Pagination = ({
           )
         })}
 
-        <Icon name="arrow-right" onClick={nextButton} title="forward" />
+        {maxCount > 1 && (
+          <Icon name="arrow-right" onClick={nextButton} title="forward" />
+        )}
       </Box>
     </Stack>
   )

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -1,0 +1,151 @@
+import React, { useState, useEffect } from 'react'
+import styled from 'styled-components'
+import Box from './box'
+import Text from './text'
+import Stack from './stack'
+import Select from './select'
+import Icon from './icon/icon'
+
+const PaginationButton = styled(Box)`
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 13px;
+  transition: 0.3s;
+
+  &:hover {
+    background-color: #f7f7f7;
+  }
+`
+
+const PrevButton = styled(Icon)`
+  transform: rotate(180deg);
+`
+
+interface PaginationProps {
+  onPageChange: (offset: number) => {}
+  rowsPerPage: number
+  total: number
+  count?: number
+  rowsPerPageOptions?: {
+    display: any
+    value: number
+  }[]
+  showRowSelector?: boolean
+  showResultCount?: boolean
+}
+
+const defaultRowsPerPage = [
+  { value: 10, display: 10 },
+  { value: 50, display: 50 },
+  { value: 100, display: 100 },
+]
+
+const Pagination = ({
+  count = 3,
+  total,
+  onPageChange,
+  rowsPerPage,
+  rowsPerPageOptions = defaultRowsPerPage,
+  showRowSelector = false,
+  showResultCount = false,
+  ...props
+}: PaginationProps): React.ReactNode => {
+  const [current, setCurrent] = useState(1)
+  const [currentIdx, setCurrentIdx] = useState(0)
+  const [countPerPage, setCountPerPage] = useState(rowsPerPage)
+  const [turns, setTurns] = useState(1)
+  const offset = (current - 1) * countPerPage
+
+  const onPageSelect = (page, idx) => {
+    setCurrent(page)
+    if (idx === 0 && page !== 1) {
+      setCurrentIdx(Math.ceil((count - 1) / 2))
+      setTurns(turns - 1)
+    } else if (idx > Math.ceil((count - 1) / 2)) {
+      setCurrentIdx(Math.ceil((count - 1) / 2))
+      setTurns(turns + 1)
+    } else {
+      setCurrentIdx(idx)
+    }
+  }
+
+  const prevButton = () => {
+    if (current > 1) {
+      const prevPage = current - 1
+      const prevIndex =
+        currentIdx < 1 ? Math.ceil((count - 1) / 2) : currentIdx - 1
+      onPageSelect(prevPage, prevIndex)
+    }
+  }
+
+  const nextButton = () => {
+    if (current < Math.ceil(total / countPerPage)) {
+      const nextPage = current + 1
+      const nextIndex =
+        currentIdx >= count - 1 ? Math.ceil((count - 1) / 2) : currentIdx + 1
+      onPageSelect(nextPage, nextIndex)
+    }
+  }
+
+  useEffect(() => {
+    onPageChange(offset)
+  }, [current])
+
+  return (
+    <Stack
+      display="inline-flex"
+      flexDirection="row"
+      mt={3}
+      width="100%"
+      {...props}
+    >
+      {showRowSelector && (
+        <Box mr={4}>
+          <Text alignSelf="center" mr={2} variant="milli">
+            Rows per page:
+          </Text>
+          <Select
+            id="row-selector"
+            onChange={item => setCountPerPage(item)}
+            options={rowsPerPageOptions}
+            value={countPerPage}
+          />
+        </Box>
+      )}
+      {showResultCount && (
+        <Text mr={4}>
+          {offset + 1}-{current * countPerPage} of {total}
+        </Text>
+      )}
+      <Box key="pagination" alignItems="center" justifyContent="center">
+        {current > 1 && (
+          <PrevButton
+            mr={3}
+            name="arrow-right"
+            onClick={prevButton}
+            title="back"
+          />
+        )}
+        {new Array(count).fill(1).map((_, idx) => {
+          const pageNumber =
+            currentIdx > Math.ceil((count - 1) / 2)
+              ? current + idx
+              : idx + turns
+          return (
+            <PaginationButton
+              key={`page-${pageNumber}-${idx}`}
+              bg={current === pageNumber ? 'whiteDark' : 'greyLightest'}
+              mr={3}
+              onClick={() => onPageSelect(pageNumber, idx)}
+            >
+              <Text> {pageNumber} </Text>
+            </PaginationButton>
+          )
+        })}
+        <Icon name="arrow-right" onClick={nextButton} title="forward" />
+      </Box>
+    </Stack>
+  )
+}
+
+export default Pagination

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useLayoutEffect } from 'react'
+import React, { useState, useRef, useLayoutEffect, useEffect } from 'react'
 import styled from 'styled-components'
 import Box from './box'
 import Text from './text'
@@ -54,7 +54,7 @@ const Pagination = ({
   const [currentIdx, setCurrentIdx] = useState(0)
   const [countPerPage, setCountPerPage] = useState(rowsPerPage)
   const [turns, setTurns] = useState(1)
-  const offset = (current - 1) * countPerPage
+  let offset = (current - 1) * countPerPage
   const didMount = useRef(true) // used to track if this is the first time the component renders
 
   const lastPage = Math.ceil(total / countPerPage)
@@ -102,7 +102,14 @@ const Pagination = ({
       return
     }
     onPageChange(offset, countPerPage)
-  }, [current, countPerPage])
+  }, [current])
+
+  useEffect(() => {
+    offset = 0
+    setCurrent(1)
+    setCurrentIdx(0)
+    setTurns(1)
+  }, [countPerPage])
 
   return (
     <Stack

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import Radio from './components/radio'
 import Selector from './components/selector'
 import InputStepper from './components/input-stepper'
 import Select from './components/select'
+import Pagination from './components/pagination'
 import ProgressBar from './components/progress-bar'
 import { ThemeProvider, theme, redesignTheme, GlobalStyle } from './styles'
 
@@ -40,6 +41,7 @@ export {
   Loader,
   Message,
   ModalProvider,
+  Pagination,
   ProgressBar,
   Radio,
   Section,


### PR DESCRIPTION
## FIX
- should now be able to sort by rows per page
- should not display more than the `total/rows` pages
- should reset pagination if user changes rows per page