### PR TITLE
U27835 Add component version bump dispatch workflow

### DIFF
--- a/.github/workflows/ui-bump-dispatch.yml
+++ b/.github/workflows/ui-bump-dispatch.yml
@@ -1,0 +1,34 @@
+name: trigger ui dispatch
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  trigger-dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          registry-url: 'https://registry.npmjs.org'
+      - uses: actions/checkout@v3
+      - name: Version and publish to npm
+        uses: bcomnes/npm-bump@v2.0.2
+        with:
+          git_email: rebeldevs@momentous.ca
+          git_username: Rebel Version Bumper
+          newversion: patch
+          push_version_commit: true
+          github_token: ${{ secrets.ACTIONS_TOKEN }}
+          npm_token: ${{ secrets.NPM_TOKEN }}
+      - name: get-npm-version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@main
+      - name: repository dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.ACTIONS_TOKEN }}
+          repository: rebeldotcom/rebel-web-ui
+          event-type: components-version-bump
+          client-payload: '{"version": "${{ steps.package-version.outputs.current-version }}"}'


### PR DESCRIPTION
## Description

U27835 https://rebel.tpondemand.com/entity/27835-create-github-actions-to-auto-bump

- Adds Github Action to trigger components dependency bump in [rebel-web-ui](https://github.com/rebeldotcom/rebel-web-ui) when components is updated.

## Related PR's

https://github.com/rebeldotcom/rebel-web-cms/pull/1593
https://github.com/rebeldotcom/rebel-web-ui/pull/1239