### PR TITLE
Add deploy workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,10 @@
-name: deploy
+name: build
 on:
   workflow_dispatch:
     inputs:
-      push-downstream:
+      deploy:
         type: boolean
-        description: 'Push downstream'
+        description: 'Deploy'
         required: true
 
 concurrency:
@@ -41,7 +41,7 @@ jobs:
         id: package-version
         uses: martinbeentjes/npm-get-version-action@main
       - name: cms dispatch
-        if: ${{ inputs.push-downstream }}
+        if: ${{ inputs.deploy }}
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.GH_CI_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
           event-type: components-version-bump
           client-payload: '{"version": "${{ steps.package-version.outputs.current-version }}"}'
       - name: ui dispatch
-        if: ${{ inputs.push-downstream }}
+        if: ${{ inputs.deploy }}
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.GH_CI_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
           event-type: components-version-bump
           client-payload: '{"version": "${{ steps.package-version.outputs.current-version }}"}'
       - name: src dispatch
-        if: ${{ inputs.push-downstream }}
+        if: ${{ inputs.deploy }}
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.GH_CI_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,7 @@ on:
         description: 'Deploy'
         required: true
 
-concurrency:
-  group: ${{ github.workflow }}
+concurrency: ci-${{ github.ref }}
 
 jobs:
   trigger-dispatch:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,14 @@
-name: trigger cms bump
+name: deploy
 on:
-  push:
-    branches:
-      - 'main'
-    paths-ignore:
-      - package.json
-      - package-lock.json
+  workflow_dispatch:
+    inputs:
+      push-downstream:
+        type: boolean
+        description: 'Push downstream'
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}
 
 jobs:
   trigger-dispatch:
@@ -38,6 +41,7 @@ jobs:
         id: package-version
         uses: martinbeentjes/npm-get-version-action@main
       - name: cms dispatch
+        if: ${{ inputs.push-downstream }}
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.GH_CI_TOKEN }}
@@ -45,6 +49,7 @@ jobs:
           event-type: components-version-bump
           client-payload: '{"version": "${{ steps.package-version.outputs.current-version }}"}'
       - name: ui dispatch
+        if: ${{ inputs.push-downstream }}
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.GH_CI_TOKEN }}
@@ -52,6 +57,7 @@ jobs:
           event-type: components-version-bump
           client-payload: '{"version": "${{ steps.package-version.outputs.current-version }}"}'
       - name: src dispatch
+        if: ${{ inputs.push-downstream }}
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.GH_CI_TOKEN }}


### PR DESCRIPTION
## Description

Add a workflow to trigger deployment downstream to rebel-web-cms, ui, and src. Has a "push downstream" boolean to default to only packaging and pushing to NPM, or to do this and update it in the downstream repositories.