### PR TITLE
Migrated table components from cms and Password strength fix

### DIFF
--- a/src/components/password-strength-bar.tsx
+++ b/src/components/password-strength-bar.tsx
@@ -46,9 +46,10 @@ function PasswordStrengthBar({
     colors.success[500],
   ],
   showLabels = false,
+  showFeedback = false,
 }) {
   const [pwScore, setScore] = useState(0)
-  const [pwFeedback, setFeedback] = useState('')
+  const [pwFeedback, setFeedback] = useState(null)
   const [previousPw, setPrevPw] = useState(password)
 
   const calculateScore = () => {
@@ -59,7 +60,9 @@ function PasswordStrengthBar({
       setFeedback(feedback)
     } else {
       setScore(0)
-      setFeedback(`Password must be at least ${minLength}`)
+      setFeedback({
+        warning: `Password must be at least ${minLength} characters`,
+      })
     }
   }
 
@@ -75,6 +78,11 @@ function PasswordStrengthBar({
 
   return (
     <StyledStack>
+      {showLabels && password !== '' && (
+        <Text variant="milli" width={width}>
+          {scoreWords[pwScore]}
+        </Text>
+      )}
       <ProgressIndicator
         borderRadius={borderRadius}
         color={scoreColors[pwScore]}
@@ -84,9 +92,9 @@ function PasswordStrengthBar({
         variant="inverted"
         width={width}
       />
-      {showLabels && (
+      {showFeedback && (
         <Text variant="milli" width={width}>
-          {scoreWords[pwScore]}
+          {pwFeedback?.warning}
         </Text>
       )}
     </StyledStack>

--- a/src/components/password-strength-bar.tsx
+++ b/src/components/password-strength-bar.tsx
@@ -37,7 +37,7 @@ function PasswordStrengthBar({
   minLength = 8,
   userInputs = [],
   scorePercentage = [0, 20, 50, 80, 100],
-  scoreWords = ['too short', 'weak', 'okay', 'good', 'strong'],
+  scoreWords = ['weak', 'weak', 'okay', 'good', 'strong'],
   scoreColors = [
     '',
     colors.destructive[500],

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -1,0 +1,5 @@
+import TableHeader from './table-header'
+import TableHeaderLabel from './table-header-label'
+import TableItem from './table-item'
+
+export { TableHeader, TableHeaderLabel, TableItem }

--- a/src/components/table/table-header-label.tsx
+++ b/src/components/table/table-header-label.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import Text from '../text'
+
+type TableHeaderLabelProps = {
+  label: string
+}
+
+function TableHeaderLabel({ label, ...props }: TableHeaderLabelProps) {
+  return (
+    <Text textTransform="uppercase" variant="kiloBold" {...props}>
+      {label}
+    </Text>
+  )
+}
+
+export default TableHeaderLabel

--- a/src/components/table/table-header.tsx
+++ b/src/components/table/table-header.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import Box from '../box'
+
+type TableHeaderProps = {
+  children: React.ReactNode
+  gridFormat: {
+    extremeRightCellWidth: string
+    gridGap: string[]
+    gridMargin: number
+    gridTemplateColumns: string[]
+  }
+}
+
+function TableHeader({ gridFormat, children, ...props }: TableHeaderProps) {
+  return (
+    <Box
+      alignSelf="center"
+      bg="white"
+      borderLeft="light"
+      borderRight="light"
+      borderTop="light"
+      display={['grid', 'grid', 'grid']}
+      gridGap={gridFormat.gridGap}
+      gridTemplateColumns={gridFormat.gridTemplateColumns}
+      pl={3}
+      py={2}
+      width="100%"
+      {...props}
+    >
+      {children}
+    </Box>
+  )
+}
+
+export default TableHeader

--- a/src/components/table/table-item.tsx
+++ b/src/components/table/table-item.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import Box from '../box'
+
+type TableItemProps = {
+  children: React.ReactNode
+  gridFormat: {
+    extremeRightCellWidth: string
+    gridGap: string[]
+    gridMargin: number
+    gridTemplateColumns: string[]
+  }
+}
+
+function TableItem({ gridFormat, children, ...props }: TableItemProps) {
+  return (
+    <Box
+      alignSelf="center"
+      bg="white"
+      borderBottom="light"
+      borderLeft="light"
+      borderRight="light"
+      borderTop="light"
+      display={['flex', 'grid', 'grid']}
+      gridGap={gridFormat.gridGap}
+      gridTemplateColumns={gridFormat.gridTemplateColumns}
+      justifyContent="space-between"
+      width="100%"
+      {...props}
+    >
+      {children}
+    </Box>
+  )
+}
+
+export default TableItem

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import ProgressIndicator from './components/progress-indicator'
 import PasswordStrengthBar from './components/password-strength-bar'
 import AlertInline from './components/alert-inline'
 import IndeterminateLinearProgress from './components/indeterminate-progress-bar'
+import { TableHeader, TableHeaderLabel, TableItem } from './components/table'
 import {
   ThemeProvider,
   theme,
@@ -77,4 +78,7 @@ export {
   useModal,
   iconRepo,
   PasswordStrengthBar,
+  TableHeader,
+  TableHeaderLabel,
+  TableItem,
 }


### PR DESCRIPTION
Migrated the components used to create the email manager and SEO tools grid.
These components used to exist in CMS, but their rightful spot should be in components.

## Sample
![image](https://user-images.githubusercontent.com/12716559/206315665-8c4edcb3-064a-44f6-95b6-a6b024aa12a4.png)


[TP-31174](https://rebel.tpondemand.com/entity/31174-ox-fe-long-passwords-display-as)
Also fix the password strength bar since I'm here.
- Shows feedback
- too short is now replaced with weak
- weak passwords receive feedback

## Sample
![image](https://user-images.githubusercontent.com/12716559/206323328-d36838bb-cd3e-4fd7-977d-b37a510a134d.png)
![image](https://user-images.githubusercontent.com/12716559/206323423-f3403797-97dd-406d-9e66-fc6c32bc8fc6.png)
![image](https://user-images.githubusercontent.com/12716559/206323473-64ab6009-2351-449f-9731-93e7d283d702.png)
![image](https://user-images.githubusercontent.com/12716559/206323893-4015f606-35c6-4b9d-bc10-42184816f0ef.png)

