### PR TITLE
Fix form submission

### DIFF
--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -82,7 +82,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={disabled}
         display={display}
         id={id}
-        onClick={handleButtonClick}
+        onClick={onClick && handleButtonClick}
         title={title || ariaLabel}
         type="button"
         {...rest}


### PR DESCRIPTION
In this function:

```
    const handleButtonClick: React.MouseEventHandler<
      HTMLButtonElement
    > = event => {
      event.preventDefault()
      if (onClick) {
        onClick(event)
      }
    }
```

We prevent the default behaviour, in this case - submit. We should only do that if an onClick event was passed to us, which was the behaviour prior to my changes (shame on me).