### PR TITLE
Remove Types build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,10 @@
   "description": "Rebel web components",
   "main": "build/index.js",
   "module": "build/index.es.js",
-  "types": "build/types/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build:types": "tsc --project tsconfig.json",
-    "build": "rollup -c && npm run build:types",
+    "build": "rollup -c",
     "start": "rollup -c -w",
     "version:patch": "npm version patch && git push",
     "version:minor": "npm version minor && git push",


### PR DESCRIPTION
I did the work to fix the TS issues in this project, but a lot more work needs to be done to make sure we don't have errors everywhere in consuming codebases trying to use this project. 

Types are pretty finicky with styled-system, so it's going to take some effort. Until I have time for that, I'd like to remove the types build step, because it just interferes with work in consuming projects by showing errors everywhere, making it more difficult to find and fix real typescript errors.

Example - This is all valid code, but the errors are everywhere:
![image](https://github.com/user-attachments/assets/2babce32-88b9-4ca7-a4ce-f5d33c0630c3)

